### PR TITLE
Fix scrollIndicatorInsets for iOS 7

### DIFF
--- a/LocationPickerView/LocationPickerView.m
+++ b/LocationPickerView/LocationPickerView.m
@@ -80,6 +80,10 @@
         self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth |
         UIViewAutoresizingFlexibleHeight;
         
+        if ([self.delegate respondsToSelector:@selector(setAutomaticallyAdjustsScrollViewInsets:)]) {
+            self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(64.0, 0.0, 0.0, 0.0);
+        }
+        
         // Add scroll view KVO
         void *context = (__bridge void *)self;
         [self.tableView addObserver:self forKeyPath:@"contentOffset" options:NSKeyValueObservingOptionNew context:context];


### PR DESCRIPTION
This is so the scroll indicator doesn't start underneath the navigationBar on iOS 7. I've tested it on both iOS 6 and iOS 7.
